### PR TITLE
Refactor container memory processing

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -49,9 +49,9 @@ record := []string{
 ---
 
 ### TASK-002: Refactor processPodMemoryInfo Container Logic
-- [ ] **Analysis Complete**: Complex function breakdown identified
-- [ ] **Write Tests**: Create tests for new extracted functions
-- [ ] **Extract processContainerMemoryInfo**: Handle individual container processing
+- [x] **Analysis Complete**: Complex function breakdown identified
+- [x] **Write Tests**: Create tests for new extracted functions
+- [x] **Extract processContainerMemoryInfo**: Handle individual container processing
 - [ ] **Extract aggregatePodResources**: Handle resource aggregation logic
 - [ ] **Extract calculatePodUsageFromMetrics**: Handle usage calculation
 - [ ] **Refactor Main Function**: Update processPodMemoryInfo to use helpers


### PR DESCRIPTION
## Summary
- extract `processContainerMemoryInfo` for per-container metrics
- refactor `processPodMemoryInfo` to use new helper
- add unit test for container memory processing and update plan

## Testing
- `make test-unit`
- `make check-format`
- `make check-typing`
- `make check-style` *(fails: golangci-lint missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf35dffaf88328ae951e39962c9524