### PR TITLE
Refactor pod usage calculation into helper

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -53,9 +53,9 @@ record := []string{
 - [x] **Write Tests**: Create tests for new extracted functions
 - [x] **Extract processContainerMemoryInfo**: Handle individual container processing
 - [x] **Extract aggregatePodResources**: Handle resource aggregation logic
-- [ ] **Extract calculatePodUsageFromMetrics**: Handle usage calculation
-- [ ] **Refactor Main Function**: Update processPodMemoryInfo to use helpers
-- [ ] **Verify Tests Pass**: Ensure all existing tests still pass
+- [x] **Extract calculatePodUsageFromMetrics**: Handle usage calculation
+- [x] **Refactor Main Function**: Update processPodMemoryInfo to use helpers
+- [x] **Verify Tests Pass**: Ensure all existing tests still pass
 - [ ] **Performance Test**: Verify no performance regression
 
 **Details**:

--- a/internal/k8s/memory_test.go
+++ b/internal/k8s/memory_test.go
@@ -125,3 +125,17 @@ func TestAggregatePodResources_SumsValues(t *testing.T) {
 		t.Fatalf("limit should be nil")
 	}
 }
+
+func TestCalculatePodUsageFromMetrics_SumsUsage(t *testing.T) {
+	metrics := &metricsv1beta1.PodMetrics{
+		Containers: []metricsv1beta1.ContainerMetrics{
+			{Usage: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")}},
+			{Usage: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")}},
+		},
+	}
+	c := &Client{}
+	usage := c.calculatePodUsageFromMetrics(metrics)
+	if usage == nil || usage.Value() != int64(300*1024*1024) {
+		t.Fatalf("wrong usage")
+	}
+}


### PR DESCRIPTION
## Summary
- extract `calculatePodUsageFromMetrics` helper and use in `processPodMemoryInfo`
- add unit test for pod usage calculation
- update refactor plan

## Testing
- `make test-unit`
- `make check-format`
- `make check-typing`
- `make check-style` *(fails: /root/go/bin/golangci-lint: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf59582ff48328aabf933db055e3af