### PR TITLE
Refactor container formatting into helper

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -80,10 +80,10 @@ func (c *Client) calculatePodUsageFromMetrics(metrics *metricsv1beta1.PodMetrics
 ## ⚠️ Priority 2: Important Refactoring (Medium Impact, Low Risk)
 
 ### TASK-003: Refactor formatPodInfo Function
-- [ ] **Analysis Complete**: Large formatting function identified
-- [ ] **Write Tests**: Create tests for formatting sections
+- [x] **Analysis Complete**: Large formatting function identified
+- [x] **Write Tests**: Create tests for formatting sections
 - [ ] **Extract formatPodBaseInfo**: Handle basic pod information formatting
-- [ ] **Extract formatContainerSection**: Handle container details formatting
+- [x] **Extract formatContainerSection**: Handle container details formatting
 - [ ] **Extract formatMetadataSection**: Handle labels and annotations
 - [ ] **Refactor Main Function**: Update formatPodInfo to use helpers
 - [ ] **Verify Output**: Ensure formatted output is identical

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -166,6 +166,20 @@ func TestFormatPodInfo_NoMetricsOverridesStatus(t *testing.T) {
 	}
 }
 
+func TestFormatContainerSection_FormatsContainers(t *testing.T) {
+	c := k8s.ContainerMemoryInfo{
+		ContainerName: "app",
+		CurrentUsage:  resource.NewQuantity(100*1024*1024, resource.BinarySI),
+		MemoryRequest: resource.NewQuantity(200*1024*1024, resource.BinarySI),
+		MemoryLimit:   resource.NewQuantity(400*1024*1024, resource.BinarySI),
+	}
+	result := formatContainerSection([]k8s.ContainerMemoryInfo{c})
+	expected := "- app | Usage: 100.0 MB | Request: 200.0 MB (50.0%) | Limit: 400.0 MB (25.0%)"
+	if !strings.Contains(result, expected) {
+		t.Fatalf("expected %q in %q", expected, result)
+	}
+}
+
 func TestGetMemoryStatus(t *testing.T) {
 	cfg := &config.Config{
 		MemoryWarningPercent: 80.0,


### PR DESCRIPTION
## Summary
- extract `formatContainerSection` helper from `formatPodInfo`
- test container formatting output
- update refactor plan

## Testing
- `make test-unit`
- `make check-format`
- `make check-style` *(fails: /root/go/bin/golangci-lint missing)*
- `make check-typing`


------
https://chatgpt.com/codex/tasks/task_e_68bfc816b1ec8328a99839b8b38bfa79