### PR TITLE
Extract pod base formatter

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -82,10 +82,10 @@ func (c *Client) calculatePodUsageFromMetrics(metrics *metricsv1beta1.PodMetrics
 ### TASK-003: Refactor formatPodInfo Function
 - [x] **Analysis Complete**: Large formatting function identified
 - [x] **Write Tests**: Create tests for formatting sections
-- [ ] **Extract formatPodBaseInfo**: Handle basic pod information formatting
+- [x] **Extract formatPodBaseInfo**: Handle basic pod information formatting
 - [x] **Extract formatContainerSection**: Handle container details formatting
-- [ ] **Extract formatMetadataSection**: Handle labels and annotations
-- [ ] **Refactor Main Function**: Update formatPodInfo to use helpers
+- [x] **Extract formatMetadataSection**: Handle labels and annotations
+- [x] **Refactor Main Function**: Update formatPodInfo to use helpers
 - [ ] **Verify Output**: Ensure formatted output is identical
 - [ ] **Test Edge Cases**: Test with various pod configurations
 

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -180,6 +180,23 @@ func TestFormatContainerSection_FormatsContainers(t *testing.T) {
 	}
 }
 
+func TestFormatPodBaseInfo_FormatsBasicInfo(t *testing.T) {
+	pod := k8s.PodMemoryInfo{
+		PodName:       "app",
+		Namespace:     "default",
+		Phase:         "Running",
+		Ready:         true,
+		CurrentUsage:  resource.NewQuantity(50*1024*1024, resource.BinarySI),
+		MemoryRequest: resource.NewQuantity(100*1024*1024, resource.BinarySI),
+		MemoryLimit:   resource.NewQuantity(200*1024*1024, resource.BinarySI),
+	}
+	result := formatPodBaseInfo(&pod)
+	expected := "🟢 default/app [Running/Ready] | Usage: 50.0 MB | Request: 100.0 MB (50.0%) | Limit: 200.0 MB (25.0%) | Limits: All | Requests: All"
+	if result != expected {
+		t.Fatalf("expected %q, got %q", expected, result)
+	}
+}
+
 func TestGetMemoryStatus(t *testing.T) {
 	cfg := &config.Config{
 		MemoryWarningPercent: 80.0,


### PR DESCRIPTION
## Summary
- extract `formatPodBaseInfo` and supporting `podStatusSymbol`
- rename metadata formatter and wire helpers into `formatPodInfo`
- document plan progress for `formatPodInfo` refactor

## Testing
- `make check-format`
- `make check-style` *(fails: /root/go/bin/golangci-lint: No such file or directory)*
- `make check-typing` *(fails: missing k8s dependencies due to network)*
- `make test-unit` *(fails: missing k8s dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68c04df0130c8328829ff391be41c151