### PR TITLE
test(monitor): cover annotation truncation

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -86,8 +86,8 @@ func (c *Client) calculatePodUsageFromMetrics(metrics *metricsv1beta1.PodMetrics
 - [x] **Extract formatContainerSection**: Handle container details formatting
 - [x] **Extract formatMetadataSection**: Handle labels and annotations
 - [x] **Refactor Main Function**: Update formatPodInfo to use helpers
-- [ ] **Verify Output**: Ensure formatted output is identical
-- [ ] **Test Edge Cases**: Test with various pod configurations
+- [x] **Verify Output**: Ensure formatted output is identical
+- [x] **Test Edge Cases**: Test with various pod configurations
 
 **Details**:
 - **File**: `internal/monitor/types.go`  
@@ -215,7 +215,7 @@ func hasMemoryResource(resources corev1.ResourceRequirements, resourceType corev
 - [ ] **Complete TASK-002**: processPodMemoryInfo - Extract container processing logic
 
 ### Phase 2: Important Refactoring (Week 2)  
-- [ ] **Complete TASK-003**: formatPodInfo - Split formatting responsibilities
+- [x] **Complete TASK-003**: formatPodInfo - Split formatting responsibilities
 - [ ] **Complete TASK-004**: LoadWithCLI - Separate configuration concerns
 
 ### Phase 3: Nice-to-Have (Week 3)
@@ -278,7 +278,7 @@ For each task:
 
 ### Overall Progress
 - [ ] **Phase 1 Complete** (1/2 tasks) - 50% ✅
-- [ ] **Phase 2 Complete** (0/2 tasks)  
+- [ ] **Phase 2 Complete** (1/2 tasks) - 50% ✅  
 - [ ] **Phase 3 Complete** (0/3 tasks)
 - [ ] **All Success Metrics Met**
 - [ ] **Documentation Updated**

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -565,3 +565,14 @@ func TestPrintAnalysis_FiltersPartialLimitPods(t *testing.T) {
 		t.Fatalf("expected pod with All limits to appear, got: %s", out)
 	}
 }
+func TestFormatRequestedAnnotations_TruncatesLongValues(t *testing.T) {
+	annotations := map[string]string{"key": strings.Repeat("a", 100)}
+	result := formatRequestedAnnotations(annotations, []string{"key"})
+	expected := "key: " + strings.Repeat("a", 77) + "..."
+	if len(result) != 1 {
+		t.Fatalf("expected one annotation, got %d", len(result))
+	}
+	if result[0] != expected {
+		t.Errorf("expected %q, got %q", expected, result[0])
+	}
+}


### PR DESCRIPTION
## Summary
- test annotation truncation in metadata formatting
- update plan: mark formatPodInfo refactor complete and progress

## Testing
- `make check-format`
- `make check-typing`
- `make check-style`
- `make test-unit`


------
https://chatgpt.com/codex/tasks/task_e_68c0536d91ec83288210a1e0248af9ea